### PR TITLE
fix(grammar): repair tree-sitter integration and add query validation

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -13,22 +13,26 @@ on:
 
 permissions: {}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   analyze:
     name: Analyze
     runs-on: ubuntu-latest
     permissions:
-      actions: read
-      contents: read
-      packages: read
-      security-events: write
+      actions: read # read workflow run metadata for the actions language pack
+      contents: read # check out the repository source
+      packages: read # pull CodeQL bundles and dependencies
+      security-events: write # upload analysis results to code scanning
     strategy:
       fail-fast: false
       matrix:
         language: ["actions"]
     steps:
       - name: CodeQL Analysis
-        uses: ivuorinen/actions/codeql-analysis@f2d15a840e8888ba4f0c348ea70b6522cf2dc541 # v2026.04.15
+        uses: ivuorinen/actions/codeql-analysis@8395dad6b7d5d7d2e1d016cac1eede33ab404a3c # v2026.06.18
         with:
           language: ${{ matrix.language }}
           queries: security-and-quality

--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -12,7 +12,7 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-permissions: read-all
+permissions: {}
 
 jobs:
   Linter:
@@ -20,11 +20,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
-      statuses: write
-      contents: read
-      packages: read
+      statuses: write # post lint status checks back to the commit
+      contents: read # check out the repository source
+      packages: read # pull linter dependencies
 
     steps:
       - name: Run PR Lint
         # https://github.com/ivuorinen/actions
-        uses: ivuorinen/actions/pr-lint@f2d15a840e8888ba4f0c348ea70b6522cf2dc541 # v2026.04.15
+        uses: ivuorinen/actions/pr-lint@8395dad6b7d5d7d2e1d016cac1eede33ab404a3c # v2026.06.18

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -8,10 +8,14 @@ on:
   workflow_call:
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
-  contents: read
-  packages: read
-  statuses: read
+  contents: read # check out the repository source
+  packages: read # pull action dependencies
+  statuses: read # read commit statuses when evaluating staleness
 
 jobs:
   stale:
@@ -20,7 +24,7 @@ jobs:
 
     permissions:
       contents: write # only for delete-branch option
-      issues: write
-      pull-requests: write
+      issues: write # comment on and close stale issues
+      pull-requests: write # comment on and close stale pull requests
     steps:
-      - uses: ivuorinen/actions/stale@f2d15a840e8888ba4f0c348ea70b6522cf2dc541 # v2026.04.15
+      - uses: ivuorinen/actions/stale@8395dad6b7d5d7d2e1d016cac1eede33ab404a3c # v2026.06.18

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -20,7 +20,7 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-permissions: read-all
+permissions: {}
 
 jobs:
   labels:
@@ -29,13 +29,14 @@ jobs:
     timeout-minutes: 10
 
     permissions:
-      contents: read
-      issues: write
+      contents: read # check out the repository source
+      issues: write # create and update repository labels
 
     steps:
       - name: ⤵️ Checkout Repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          persist-credentials: false
       - name: ⤵️ Sync Latest Labels Definitions
-        uses: ivuorinen/actions/sync-labels@f2d15a840e8888ba4f0c348ea70b6522cf2dc541 # v2026.04.15
+        uses: ivuorinen/actions/sync-labels@8395dad6b7d5d7d2e1d016cac1eede33ab404a3c # v2026.06.18

--- a/.github/workflows/validate-queries.yml
+++ b/.github/workflows/validate-queries.yml
@@ -1,0 +1,40 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+name: Validate Queries
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'languages/**/*.scm'
+      - 'extension.toml'
+      - 'scripts/validate-queries.py'
+      - '.github/workflows/validate-queries.yml'
+  pull_request:
+    paths:
+      - 'languages/**/*.scm'
+      - 'extension.toml'
+      - 'scripts/validate-queries.py'
+      - '.github/workflows/validate-queries.yml'
+  merge_group:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  validate-queries:
+    name: Validate tree-sitter queries
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read # check out the repository source
+    steps:
+      - name: ⤵️ Checkout Repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - name: ✅ Validate query node types against pinned grammar
+        run: python3 scripts/validate-queries.py

--- a/README.md
+++ b/README.md
@@ -7,8 +7,9 @@ Language support for ShellSpec BDD testing framework in Zed editor.
 - Syntax highlighting for ShellSpec DSL keywords
 - Smart indentation for nested test blocks
 - Code outline navigation
-- Bracket matching and auto-completion
-- Test execution integration
+- Bracket matching and auto-close pairs
+- Test execution integration (runnable test/suite detection)
+- Shell completion and diagnostics via bash-language-server
 
 ## Installation
 

--- a/docs/audit/nitpicker-findings.md
+++ b/docs/audit/nitpicker-findings.md
@@ -1,0 +1,131 @@
+# Nitpicker Findings
+Generated: 2026-06-24
+Last validated: 2026-06-25
+
+## Summary
+- Total: 10 | Open: 0 | Fixed: 10 | Invalid: 0
+- Critical: 2 | High: 3 | Medium: 2 | Low: 3 (all fixed)
+
+## Open Findings
+
+_None._
+
+## Fixed
+
+### Pass 1 — 2026-06-25
+
+#### [N-010] All query files reference non-existent node `simple_command`
+Severity: Critical
+Category: correctness
+Area: languages/shellspec/{highlights,brackets,indents,outline,runnables,injections}.scm
+Problem: Every query used `(simple_command ...)`, but tree-sitter-bash has no
+`simple_command` node — the node is `command` (field `name:` → `command_name`).
+A query referencing an unknown node type fails to compile and disables the entire
+query file in Zed.
+Evidence: `node-types.json` at the pinned grammar rev contains `command` (with
+`name: command_name`) and no `simple_command`; verified programmatically.
+Fixed: 2026-06-25
+Notes: Replaced `simple_command` → `command` across all six query files. Added
+scripts/validate-queries.py which flags exactly this class of error (confirmed it
+reports `simple_command` as unknown and passes the corrected files).
+
+#### [N-001] Grammar name mismatch — extension loads no grammar
+Severity: Critical
+Category: correctness
+Area: extension.toml, languages/shellspec/config.toml
+Problem: `extension.toml` declared `[grammars.shellspec]` while `config.toml` set
+`grammar = "bash"` — no `bash` grammar is declared, so Zed loads no parser and
+every tree-sitter feature is dead.
+Fixed: 2026-06-25
+Notes: Set `config.toml` `grammar = "shellspec"` to match the declared grammar.
+
+#### [N-002] Grammar `rev` pinned to a moving branch, not a commit SHA
+Severity: High
+Category: reliability
+Area: extension.toml
+Problem: `rev = "main"` is non-reproducible and rejected by the Zed extensions
+registry, which requires a commit SHA.
+Fixed: 2026-06-25
+Notes: Pinned `rev = "a06c2e4415e9bc0346c6b86d401879ffb44058f7"`
+(tree-sitter/tree-sitter-bash master HEAD at fix time). Renovate can bump it.
+
+#### [N-003] BDD keyword highlighting via `["Literal"]` patterns never matched
+Severity: High
+Category: correctness
+Area: languages/shellspec/highlights.scm
+Problem: Keyword highlighting used anonymous-token list syntax
+(`["Describe" ...] @keyword.function`), which matches grammar tokens; ShellSpec
+keywords are `command_name`/`word` nodes, so the rules matched nothing.
+Fixed: 2026-06-25
+Notes: Rewrote highlights.scm to predicate form — structure/hook/control/helper
+keywords match `(command_name)` with `#match?`; assertion/matcher/modifier/chain
+words match `(word)` with `#match?`. Node references validated against the
+grammar. Visual scope precedence (generic `@function` first, keyword scopes
+after) follows Zed's last-match convention and should be eyeballed in a live Zed
+preview, but the rules now match the correct nodes — which was the defect.
+
+#### [N-004] Runnables never triggered for quoted test descriptions
+Severity: High
+Category: correctness
+Area: languages/shellspec/runnables.scm
+Problem: Patterns required a `(word)` description, but idiomatic ShellSpec quotes
+descriptions (`It 'returns 0'`), which parse as `string`/`raw_string`.
+Fixed: 2026-06-25
+Notes: Changed the description capture to `[(word) (string) (raw_string)] @run`
+in all five rules (and `simple_command` → `command` per N-010).
+
+#### [N-005] Outline omitted entries for quoted descriptions
+Severity: Medium
+Category: maintainability
+Area: languages/shellspec/outline.scm
+Problem: Same root cause as N-004 — `(word) @name` missed quoted descriptions.
+Fixed: 2026-06-25
+Notes: Changed to `[(word) (string) (raw_string)] @name` in each rule.
+
+#### [N-006] Query files were never validated against the grammar
+Severity: Medium
+Category: tests
+Area: scripts/validate-queries.py, .github/workflows/validate-queries.yml
+Problem: No CI/pre-commit step parsed the `.scm` queries against the grammar, so
+node-type errors (N-010) and dead rules (N-003/004/005/007) shipped silently.
+Fixed: 2026-06-25
+Notes: Added scripts/validate-queries.py (stdlib-only) that reads the pinned
+grammar rev from extension.toml, fetches its node-types.json, and verifies every
+node type referenced in languages/**/*.scm exists. Wired it into a new
+validate-queries.yml workflow (zizmor-clean, minimal permissions, pinned
+checkout). Verified earlier suspicions: `number` and `arithmetic_expansion` DO
+exist in the grammar (no fix needed there); the real defect was `simple_command`.
+
+#### [N-007] Dead highlight rules that can never match a single `word` node
+Severity: Low
+Category: correctness
+Area: languages/shellspec/highlights.scm
+Problem: `(word) ... (#match? "^Skip\\s+if$")` (a word has no whitespace) and
+`(word) ... (#eq? "#|")` (`#|` lexes as a comment) never matched.
+Fixed: 2026-06-25
+Notes: Removed both inert rules during the highlights.scm rewrite.
+
+#### [N-008] brackets.scm Describe/End pair could not match as a bracket pair
+Severity: Low
+Category: correctness
+Area: languages/shellspec/brackets.scm
+Problem: `@open` and `@close` were in two separate top-level patterns (and used
+the non-existent `simple_command`), so Zed could not associate them as a pair.
+Fixed: 2026-06-25
+Notes: Removed the non-functional Describe/End block; kept the correct quote,
+command-substitution, paren, bracket, and brace delimiter pairs.
+
+#### [N-009] README listed capabilities the extension does not provide
+Severity: Low
+Category: docs
+Area: README.md
+Problem: Features listed "auto-completion" as an extension capability; completion
+comes from bash-language-server, not the extension.
+Fixed: 2026-06-25
+Notes: Reworded to "Bracket matching and auto-close pairs", clarified test
+execution as runnable detection, and attributed completion/diagnostics to
+bash-language-server.
+
+## Invalid
+
+_None._

--- a/extension.toml
+++ b/extension.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/ivuorinen/shellspec-zed"
 
 [grammars.shellspec]
 repository = "https://github.com/tree-sitter/tree-sitter-bash"
-rev = "main"
+rev = "a06c2e4415e9bc0346c6b86d401879ffb44058f7"
 
 [language_servers.bash-language-server]
 name = "Bash Language Server"

--- a/languages/shellspec/brackets.scm
+++ b/languages/shellspec/brackets.scm
@@ -14,12 +14,3 @@
 
 ; Curly braces
 ("{" @open "}" @close)
-
-; ShellSpec block structure (if using End keyword)
-(simple_command
-  (command_name) @_cmd
-  (#match? @_cmd "^(Describe|Context|It|Specify|Example)$")) @open
-
-(simple_command
-  (command_name) @_end
-  (#eq? @_end "End")) @close

--- a/languages/shellspec/config.toml
+++ b/languages/shellspec/config.toml
@@ -1,5 +1,5 @@
 name = "ShellSpec"
-grammar = "bash"
+grammar = "shellspec"
 path_suffixes = ["_spec.sh", ".spec.sh"]
 line_comments = ["# "]
 tab_size = 2

--- a/languages/shellspec/highlights.scm
+++ b/languages/shellspec/highlights.scm
@@ -1,47 +1,57 @@
-; BDD Structure Keywords
-["Describe" "Context" "ExampleGroup"] @keyword.function
-["It" "Specify" "Example"] @keyword.function
-["Todo"] @keyword.function
+; ShellSpec keywords are ordinary shell commands/arguments in the bash grammar,
+; not anonymous grammar tokens. They must be matched as (command_name) / (word)
+; nodes with predicates — a bare ["Describe"] list matches nothing.
+
+; Generic command name (overridden by the keyword rules below).
+(command_name) @function
+
+; BDD structure keywords (statement-leading command names)
+((command_name) @keyword.function
+  (#match? @keyword.function "^(Describe|Context|ExampleGroup|It|Specify|Example|Todo)$"))
 
 ; Prefixed block keywords
-["xDescribe" "xContext" "xExampleGroup" "xIt" "xSpecify" "xExample"] @keyword.function.inactive
-["fDescribe" "fContext" "fExampleGroup" "fIt" "fSpecify" "fExample"] @keyword.function.focus
+((command_name) @keyword.function.inactive
+  (#match? @keyword.function.inactive "^x(Describe|Context|ExampleGroup|It|Specify|Example)$"))
+((command_name) @keyword.function.focus
+  (#match? @keyword.function.focus "^f(Describe|Context|ExampleGroup|It|Specify|Example)$"))
 
-; Control flow
-["Pending" "Skip"] @keyword.control
-["When" "The" "Assert"] @keyword.control
-["End"] @keyword.control
+; Control flow keywords
+((command_name) @keyword.control
+  (#match? @keyword.control "^(Pending|Skip|When|The|Assert|End)$"))
 
 ; Hook keywords
-["BeforeEach" "AfterEach" "BeforeAll" "AfterAll"] @keyword.function
-["BeforeCall" "AfterCall" "BeforeRun" "AfterRun"] @keyword.function
-["Before" "After"] @keyword.function
+((command_name) @keyword.function
+  (#match? @keyword.function "^(BeforeEach|AfterEach|BeforeAll|AfterAll|BeforeCall|AfterCall|BeforeRun|AfterRun|Before|After)$"))
 
 ; Helper keywords
-["Include" "Set" "Data" "Parameters" "Dump"] @keyword
-["Path" "File" "Dir"] @keyword
+((command_name) @keyword
+  (#match? @keyword "^(Include|Set|Data|Parameters|Dump|Path|File|Dir)$"))
 
-; Evaluation keywords
-["call" "run" "command" "script" "source"] @function.method
+; Evaluation keywords (appear as arguments, e.g. `When call ...`)
+((word) @function.method
+  (#match? @function.method "^(call|run|command|script|source)$"))
 
 ; Assertion keywords
-["should" "not"] @keyword.operator
-["output" "stdout" "error" "stderr" "status" "variable" "path"] @variable.builtin
+((word) @keyword.operator
+  (#match? @keyword.operator "^(should|not)$"))
+((word) @variable.builtin
+  (#match? @variable.builtin "^(output|stdout|error|stderr|status|variable|path)$"))
 
 ; Matchers
-["equal" "eq" "be" "exist" "valid" "satisfy"] @function.method
-["match" "start_with" "end_with" "include" "contain"] @function.method
+((word) @function.method
+  (#match? @function.method "^(equal|eq|be|exist|valid|satisfy|match|start_with|end_with|include|contain)$"))
 
 ; Modifiers
-["line" "word" "length" "contents" "result"] @variable.parameter
-["first" "second" "third" "of"] @variable.parameter
+((word) @variable.parameter
+  (#match? @variable.parameter "^(line|word|length|contents|result|first|second|third|of)$"))
 
 ; Language chains
-["a" "an" "as" "the"] @keyword.operator
+((word) @keyword.operator
+  (#match? @keyword.operator "^(a|an|as|the)$"))
 
-; Skip conditional
-(word) @keyword.control
-  (#match? @keyword.control "^Skip\\s+if$")
+; Tags (key:value pairs)
+((word) @label
+  (#match? @label "^\\w+:\\w+$"))
 
 ; Test descriptions and strings
 (string) @string
@@ -60,14 +70,3 @@
 ; Function definitions
 (function_definition
   name: (word) @function)
-
-; Command names
-(command_name) @function
-
-; Data block markers
-(word) @punctuation.special
-  (#eq? @punctuation.special "#|")
-
-; Tags (key:value pairs)
-(word) @label
-  (#match? @label "\\w+:\\w+")

--- a/languages/shellspec/indents.scm
+++ b/languages/shellspec/indents.scm
@@ -1,20 +1,20 @@
 ; Indent content inside BDD blocks
-(simple_command
+(command
   (command_name) @_name
   (#match? @_name "^(Describe|Context|ExampleGroup|It|Specify|Example)$")) @indent
 
 ; Indent prefixed blocks
-(simple_command
+(command
   (command_name) @_name
   (#match? @_name "^[xf](Describe|Context|ExampleGroup|It|Specify|Example)$")) @indent
 
 ; Indent hook content
-(simple_command
+(command
   (command_name) @_name
   (#match? @_name "^(BeforeEach|AfterEach|BeforeAll|AfterAll|BeforeCall|AfterCall|BeforeRun|AfterRun)$")) @indent
 
 ; Indent Data blocks
-(simple_command
+(command
   (command_name) @_name
   (#match? @_name "^(Data|Parameters)$")) @indent
 
@@ -33,6 +33,6 @@
 (pipeline) @indent
 
 ; Dedent End keyword
-(simple_command
+(command
   (command_name) @_name
   (#eq? @_name "End")) @dedent

--- a/languages/shellspec/injections.scm
+++ b/languages/shellspec/injections.scm
@@ -11,7 +11,7 @@
   ")" @injection.punctuation.bracket)
 
 ; Inject shell in When blocks with call/run
-(simple_command
+(command
   (command_name) @_when
   (#eq? @_when "When")
   (word) @_action

--- a/languages/shellspec/outline.scm
+++ b/languages/shellspec/outline.scm
@@ -1,32 +1,32 @@
 ; Test suites
-(simple_command
+(command
   (command_name) @_name
   (#match? @_name "^(Describe|Context|ExampleGroup)$")
-  (word) @name) @item
+  [(word) (string) (raw_string)] @name) @item
 
 ; Individual tests
-(simple_command
+(command
   (command_name) @_name
   (#match? @_name "^(It|Specify|Example)$")
-  (word) @name) @item
+  [(word) (string) (raw_string)] @name) @item
 
 ; Focused tests
-(simple_command
+(command
   (command_name) @_name
   (#match? @_name "^f(Describe|Context|It|Specify|Example)$")
-  (word) @name) @item
+  [(word) (string) (raw_string)] @name) @item
 
 ; Skipped tests
-(simple_command
+(command
   (command_name) @_name
   (#match? @_name "^x(Describe|Context|It|Specify|Example)$")
-  (word) @name) @item
+  [(word) (string) (raw_string)] @name) @item
 
 ; Hooks
-(simple_command
+(command
   (command_name) @_name
   (#match? @_name "^(BeforeEach|AfterEach|BeforeAll|AfterAll)$")
-  (word) @name) @item
+  [(word) (string) (raw_string)] @name) @item
 
 ; Function definitions
 (function_definition

--- a/languages/shellspec/runnables.scm
+++ b/languages/shellspec/runnables.scm
@@ -1,29 +1,29 @@
 ; Individual test execution
-(simple_command
+(command
   (command_name) @_name
   (#match? @_name "^(It|Specify|Example)$")
-  (word) @run) @shellspec-test
+  [(word) (string) (raw_string)] @run) @shellspec-test
 
 ; Test suite execution
-(simple_command
+(command
   (command_name) @_name
   (#match? @_name "^(Describe|Context|ExampleGroup)$")
-  (word) @run) @shellspec-suite
+  [(word) (string) (raw_string)] @run) @shellspec-suite
 
 ; Focused test execution
-(simple_command
+(command
   (command_name) @_name
   (#match? @_name "^f(It|Specify|Example)$")
-  (word) @run) @shellspec-focused-test
+  [(word) (string) (raw_string)] @run) @shellspec-focused-test
 
 ; Focused suite execution
-(simple_command
+(command
   (command_name) @_name
   (#match? @_name "^f(Describe|Context|ExampleGroup)$")
-  (word) @run) @shellspec-focused-suite
+  [(word) (string) (raw_string)] @run) @shellspec-focused-suite
 
 ; Pending test markers
-(simple_command
+(command
   (command_name) @_name
   (#match? @_name "^(Pending|Todo)$")
-  (word) @run) @shellspec-pending
+  [(word) (string) (raw_string)] @run) @shellspec-pending

--- a/scripts/validate-queries.py
+++ b/scripts/validate-queries.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""Validate tree-sitter query files against the pinned grammar.
+
+Every named node type referenced in languages/**/*.scm must exist in the
+grammar's node-types.json at the revision pinned in extension.toml. A query
+that references a non-existent node type (e.g. `simple_command` when the bash
+grammar calls it `command`) fails to compile in Zed and silently disables the
+entire query file — this check catches that before release.
+
+No third-party dependencies; uses only the standard library.
+
+Exit codes: 0 = all references valid, 1 = unknown node type(s) found.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+import tomllib
+import urllib.request
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+EXTENSION_TOML = REPO_ROOT / "extension.toml"
+QUERY_DIR = REPO_ROOT / "languages"
+
+# Node patterns are `(node_type ...)`; named node types start lowercase or `_`.
+_NODE_REF_RE = re.compile(r"\(\s*([a-z_][A-Za-z0-9_]*)")
+# Double-quoted anonymous nodes / predicate strings — stripped before scanning
+# so regex alternations like "^(Describe|...)" are not mistaken for node types.
+_DQ_STRING_RE = re.compile(r'"(?:\\.|[^"\\])*"')
+
+
+def grammar_node_types() -> set[str]:
+    with EXTENSION_TOML.open("rb") as fh:
+        manifest = tomllib.load(fh)
+    grammars = manifest.get("grammars", {})
+    if not grammars:
+        sys.exit("error: no [grammars.*] table in extension.toml")
+    # This extension ships a single grammar; take the first.
+    name, spec = next(iter(grammars.items()))
+    repo = spec["repository"].rstrip("/").removesuffix(".git")
+    rev = spec["rev"]
+    owner_repo = "/".join(repo.split("/")[-2:])
+    url = f"https://raw.githubusercontent.com/{owner_repo}/{rev}/src/node-types.json"
+    print(f"grammar '{name}': {owner_repo}@{rev[:12]}")
+    with urllib.request.urlopen(url, timeout=30) as resp:  # noqa: S310 (pinned host)
+        data = json.load(resp)
+
+    types: set[str] = {"_"}  # `(_)` wildcard matches any node
+
+    def walk(obj: object) -> None:
+        if isinstance(obj, dict):
+            t = obj.get("type")
+            if isinstance(t, str):
+                types.add(t)
+            for value in obj.values():
+                walk(value)
+        elif isinstance(obj, list):
+            for item in obj:
+                walk(item)
+
+    walk(data)
+    return types
+
+
+def referenced_node_types(text: str) -> set[str]:
+    refs: set[str] = set()
+    for raw_line in text.splitlines():
+        line = _DQ_STRING_RE.sub('""', raw_line)
+        line = line.split(";", 1)[0]  # strip line comments
+        refs.update(_NODE_REF_RE.findall(line))
+    return refs
+
+
+def main() -> int:
+    valid = grammar_node_types()
+    query_files = sorted(QUERY_DIR.rglob("*.scm"))
+    if not query_files:
+        print("no .scm files found")
+        return 0
+
+    errors = 0
+    for qf in query_files:
+        unknown = sorted(referenced_node_types(qf.read_text()) - valid)
+        rel = qf.relative_to(REPO_ROOT)
+        if unknown:
+            errors += len(unknown)
+            for name in unknown:
+                print(f"  ERROR  {rel}: unknown node type '{name}'")
+        else:
+            print(f"  OK     {rel}")
+
+    if errors:
+        print(f"\n{errors} unknown node type reference(s).")
+        return 1
+    print(f"\nAll {len(query_files)} query file(s) reference valid node types.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Repairs the extension's tree-sitter integration (it was non-functional) and
hardens CI. Driven by an adversarial whole-repo review — full report in
`docs/audit/nitpicker-findings.md` (10 findings: 2 Critical, 3 High, 2 Medium,
3 Low; all fixed).

## Why it was broken

The extension shipped with **two independent showstoppers**, either of which
alone disabled all tree-sitter features (highlighting, indents, brackets,
outline, injections, runnables):

1. **Grammar never resolved** — `extension.toml` declared `[grammars.shellspec]`
   but `languages/shellspec/config.toml` set `grammar = "bash"`, an undeclared
   grammar. No parser loaded.
2. **Every query referenced a non-existent node** — all `.scm` files used
   `(simple_command ...)`, but tree-sitter-bash calls that node `command`. An
   unknown node type fails to compile and silently disables the whole query file.

On top of that, the keyword highlighting used `["Describe" ...]` anonymous-token
lists, which match grammar tokens — not the `command_name`/`word` nodes that
ShellSpec keywords actually are — so they matched nothing.

## Changes

**Correctness (`fix(grammar)`)**
- `config.toml`: `grammar = "shellspec"` to match the manifest
- `extension.toml`: pin grammar `rev` to a commit SHA (was the moving `main`)
- all `.scm`: `simple_command` → `command`
- `highlights.scm`: rewrite keyword rules to predicate form; drop two rules that
  can never match a single `word` node
- `runnables.scm` / `outline.scm`: accept quoted descriptions
  (`[(word) (string) (raw_string)]`) so idiomatic specs are detected
- `brackets.scm`: drop the non-functional Describe/End pair
- `README.md`: correct the overstated feature list

**Tooling (`ci`)**
- `scripts/validate-queries.py` + `validate-queries.yml`: compile-check every
  `.scm` node-type reference against the pinned grammar's `node-types.json`.
  Proven to catch the `simple_command` class of bug.

**Workflows (`chore(ci)`, already on branch)**
- zizmor `--persona auditor` hardening of the four existing workflows
  (documented permissions, job concurrency, `persist-credentials: false`).

## Verification

- `scripts/validate-queries.py` → all 6 query files reference valid node types;
  confirmed it flags the old `simple_command` and passes the fixes.
- `zizmor --persona auditor .github/workflows/` → no findings (all 5 workflows).
- yamllint + `py_compile` clean.

## Not verified

Node-type references are validated, but not a full tree-sitter query *compile*
(needs building the grammar — tracked in finding N-006). Highlight scope
precedence should be eyeballed once in a live Zed; the rules now match the
correct nodes, which was the defect.
